### PR TITLE
Fixed #10 iOS XCode7 warning message issue

### DIFF
--- a/src/xcode/libsqlcipher/libsqlcipher.xcodeproj/project.pbxproj
+++ b/src/xcode/libsqlcipher/libsqlcipher.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 		931DCCF31BE8044C0025F6F3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_MODULE_DEBUGGING = NO;
 				HEADER_SEARCH_PATHS = "$SRCROOT/../../../vendor/couchbase-lite-libcrypto/libs/include";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_CFLAGS = (
@@ -414,6 +416,8 @@
 		931DCCF41BE8044C0025F6F3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_MODULE_DEBUGGING = NO;
 				HEADER_SEARCH_PATHS = "$SRCROOT/../../../vendor/couchbase-lite-libcrypto/libs/include";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_CFLAGS = (
@@ -652,6 +656,7 @@
 				937B8A7D1C5042B300888F36 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
Set CLANG_ENABLE_MODULES = NO and CLANG_ENABLE_MODULE_DEBUGGING = NO in ios-static target settings.

#10