### PR TITLE
Fixed build issue with NDK r15 or higher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ else()
   add_definitions(-DSQLCIPHER_CRYPTO_MBEDTLS)
 endif()
 
+if(ANDROID)
+    # See: https://github.com/android-ndk/ndk/issues/477
+    add_definitions(-D_FILE_OFFSET_BITS=32)
+endif()
+
 set(SRC_FILES src/c/sqlite3.c)
 if(NOT APPLE)
   set(SRC_FILES ${SRC_FILES} src/c/crypto_mbedtls.c)


### PR DESCRIPTION
- Since NDK r15c, some methods are not defined if API version is lower than 21 and _FILE_OFFSET_BITS=64. See following link. https://github.com/android-ndk/ndk/issues/477